### PR TITLE
Exslt extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,9 @@ This module can be installed with the `go get` command:
   }
 
 ```
+
+# Exslt
+
+To enable usage of exslt extension, namespace xmlns:exsl="http://exslt.org/common" and it's functions like exsl:node-set(), You'll need to init it once at programm start
+
+    xslt.InitExslt()

--- a/README.md
+++ b/README.md
@@ -40,9 +40,3 @@ This module can be installed with the `go get` command:
   }
 
 ```
-
-# Exslt
-
-To enable usage of exslt extension, namespace xmlns:exsl="http://exslt.org/common" and it's functions like exsl:node-set(), You'll need to init it once at programm start
-
-    xslt.InitExslt()

--- a/xslt.c
+++ b/xslt.c
@@ -1,6 +1,7 @@
 #include "xslt.h"
 #include <libxslt/transform.h>
 #include <libxslt/xsltutils.h>
+#include <libexslt/exslt.h>
 #include <stdint.h>
 #include <string.h>
 

--- a/xslt.c
+++ b/xslt.c
@@ -136,3 +136,12 @@ int xslt(const char *xsl, const char *xml, char **xml_txt,
 
   return ok;
 }
+
+/*
+ * Function: init_exslt
+ * ----------------------------
+ *  Calls exsltRegisterAll() to enable exsl namespace at templates
+ */
+void init_exslt() {
+  exsltRegisterAll();
+}

--- a/xslt.go
+++ b/xslt.go
@@ -82,7 +82,6 @@ func NewStylesheet(xsl []byte) (*Stylesheet, error) {
 	return &Stylesheet{ptr: cssp}, nil
 }
 
-// InitExslt enables exsl namespace. Call this once at program start.
-func InitExslt() {
+func init() {
 	C.init_exslt()
 }

--- a/xslt.go
+++ b/xslt.go
@@ -1,7 +1,7 @@
 package xslt
 
 /*
-#cgo LDFLAGS: -lxml2 -lxslt -lz -llzma -lm
+#cgo LDFLAGS: -lxml2 -lxslt -lexslt -lz -llzma -lm
 #cgo CFLAGS: -I/usr/include -I/usr/include/libxml2
 #cgo freebsd LDFLAGS: -L/usr/local/lib
 #cgo freebsd CFLAGS: -I/usr/local/include -I/usr/local/include/libxml2
@@ -80,4 +80,9 @@ func NewStylesheet(xsl []byte) (*Stylesheet, error) {
 	}
 
 	return &Stylesheet{ptr: cssp}, nil
+}
+
+// InitExslt enables exsl namespace. Call this once at program start.
+func InitExslt() {
+	C.init_exslt()
 }

--- a/xslt.h
+++ b/xslt.h
@@ -12,4 +12,6 @@ int make_style(const char *xsl, xsltStylesheetPtr *style);
 
 int xslt(const char *xsl, const char *xml, char **xml_txt, size_t *xml_txt_len);
 
+void init_exslt();
+
 #endif


### PR DESCRIPTION
Allows to enable exslt extension, namespace xmlns:exsl="http://exslt.org/common" and it's functions like exsl:node-set()